### PR TITLE
Debian "bullseye" compatibility

### DIFF
--- a/src/notify_udp.cc
+++ b/src/notify_udp.cc
@@ -1,5 +1,6 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
+#include <stdexcept>
 #include <stdio.h>
 #include <string.h>
 #include <sys/socket.h>

--- a/src/receive_udp.cc
+++ b/src/receive_udp.cc
@@ -1,6 +1,7 @@
 #include <arpa/inet.h>
 #include <errno.h>
 #include <netinet/in.h>
+#include <stdexcept>
 #include <string.h>
 #include <sys/param.h>
 #include <sys/socket.h>

--- a/src/watch_inotify.cc
+++ b/src/watch_inotify.cc
@@ -1,5 +1,6 @@
 #include <dirent.h>
 #include <signal.h>
+#include <stdexcept>
 #include <string.h>
 #include <sys/inotify.h>
 #include <sys/stat.h>


### PR DESCRIPTION
I recently had to upgrade a base image to Debian "bullseye" and this dependency was failing to build with:

```
 > [15/20] RUN make:
#19 0.188 mkdir _build
#19 0.189 g++ -MD -g -O0 -std=c++11  -D WATCH_PLUGIN_TYPE=InotifyWatchPlugin   -c -o src/watch_null.o src/watch_null.cc
#19 0.347 g++ -MD -g -O0 -std=c++11  -D WATCH_PLUGIN_TYPE=InotifyWatchPlugin   -c -o src/notify_udp.o src/notify_udp.cc
#19 0.483 g++ -MD -g -O0 -std=c++11  -D WATCH_PLUGIN_TYPE=InotifyWatchPlugin   -c -o src/receive_udp.o src/receive_udp.cc
#19 0.586 src/receive_udp.cc: In constructor ‘UDPReceivePlugin::UDPReceivePlugin(short int, const ReceiveCallback&)’:
#19 0.586 src/receive_udp.cc:27:20: error: ‘runtime_error’ is not a member of ‘std’
#19 0.586    27 |         throw std::runtime_error("Could not create sending socket");
#19 0.586       |                    ^~~~~~~~~~~~~
#19 0.587 src/receive_udp.cc:40:20: error: ‘runtime_error’ is not a member of ‘std’
#19 0.587    40 |         throw std::runtime_error("Could not bind listening socket");
#19 0.587       |                    ^~~~~~~~~~~~~
#19 0.588 src/receive_udp.cc:49:20: error: ‘runtime_error’ is not a member of ‘std’
#19 0.588    49 |         throw std::runtime_error("Could not set socket timeout");
#19 0.588       |                    ^~~~~~~~~~~~~
#19 0.589 src/receive_udp.cc: In member function ‘virtual void UDPReceivePlugin::start()’:
#19 0.589 src/receive_udp.cc:80:24: error: ‘runtime_error’ is not a member of ‘std’
#19 0.589    80 |             throw std::runtime_error("Could not receive UDP message");
#19 0.589       |                        ^~~~~~~~~~~~~
#19 0.612 make: *** [<builtin>: src/receive_udp.o] Error 1
```

With a little research, I found [this related GitHub issue](https://github.com/Azure/azure-storage-fuse/issues/421) and my [co-worker @lritter's fork](https://github.com/lritter/notify-forwarder/) and put this together to get my build happy again.

Is this useful for others too?